### PR TITLE
Add retain white-space characters prop to LogViewer

### DIFF
--- a/packages/module/src/LogViewer/LogViewer.tsx
+++ b/packages/module/src/LogViewer/LogViewer.tsx
@@ -34,6 +34,8 @@ interface LogViewerProps {
   itemCount?: number;
   /** Flag indicating that log viewer is wrapping text or not */
   isTextWrapped?: boolean;
+  /** Flag indicating whether to preserve white-space characters */
+  retainWhitespace?: boolean;
   /** Component rendered in the log viewer console window header */
   header?: React.ReactNode;
   /** Component rendered in the log viewer console window footer */
@@ -88,6 +90,7 @@ const LogViewerBase: React.FunctionComponent<LogViewerProps> = memo(
     onScroll,
     innerRef,
     isTextWrapped = true,
+    retainWhitespace = false,
     initialIndexWidth,
     ...props
   }: LogViewerProps) => {
@@ -266,7 +269,7 @@ const LogViewerBase: React.FunctionComponent<LogViewerProps> = memo(
           className={css(
             styles.logViewer,
             hasLineNumbers && styles.modifiers.lineNumbers,
-            !isTextWrapped && styles.modifiers.nowrap,
+            !isTextWrapped && !retainWhitespace && styles.modifiers.nowrap,
             initialIndexWidth && styles.modifiers.lineNumberChars,
             theme === 'dark' && styles.modifiers.dark
           )}


### PR DESCRIPTION
The LogViewer component currently retains whitespaces only if the `isTextWrapped` prop is `true`. However, this is not always desired in cases when displaying long lines with multiple consecutive white-space characters e.g. tables.

The white-space character retention is controlled via a css property `white-space` and the added `retainWhitespace` prop can be used disable the addition of the `white-space: nowrap;` css property.

The white-space characters collapsing mangles tables in the Openshift Console UI and enabling the text wrap is not always desirable in case of logs with lengthy lines.

Fixes: #20 