### PR TITLE
expose `LogViewerProps`

### DIFF
--- a/packages/module/src/LogViewer/LogViewer.tsx
+++ b/packages/module/src/LogViewer/LogViewer.tsx
@@ -7,7 +7,7 @@ import { VariableSizeList as List, areEqual } from '../react-window';
 import styles from '@patternfly/react-styles/css/components/LogViewer/log-viewer';
 import AnsiUp from '../ansi_up/ansi_up';
 
-interface LogViewerProps {
+export interface LogViewerProps {
   /** String or String Array data being sent by the consumer*/
   data?: string | string[];
   /** Consumer may turn off the visibility on the toolbar */


### PR DESCRIPTION
## What?
This allows to re-use the props for extracted logic

## Example

```ts
import { LogViewer, LogViewerProps } from "@patternfly/react-log-viewer";

const useScrollToRow = (logs: LogViewerProps["data"] = []) => {
  const [isUserScrolling, setIsUserScrolling] = useState(false);

  const onScroll:LogViewerProps["onScroll"] = (event) => { // 👈 here we can no get the event props without having to re-define them
    if (event.scrollOffsetToBottom < 30) {
      setIsUserScrolling(false);
    } else {
      setIsUserScrolling(true);
    }
  }

  return [
    isUserScrolling ? undefined : logs.length - 1,
    onScroll,
  ] as const;
};
```