### PR TITLE
Fixes in ability to apply a dark theme only to the log viewer

### DIFF
--- a/packages/module/src/LogViewer/LogViewer.tsx
+++ b/packages/module/src/LogViewer/LogViewer.tsx
@@ -312,7 +312,7 @@ const LogViewerBase: React.FunctionComponent<LogViewerProps> = memo(
             hasLineNumbers && styles.modifiers.lineNumbers,
             !isTextWrapped && styles.modifiers.nowrap,
             initialIndexWidth && styles.modifiers.lineNumberChars,
-            theme === 'dark' && styles.themeDark
+            theme === 'dark' && styles.modifiers.dark
           )}
           {...(initialIndexWidth && {
             style: {

--- a/packages/module/src/LogViewer/css/log-viewer.css
+++ b/packages/module/src/LogViewer/css/log-viewer.css
@@ -50,14 +50,14 @@
   height: var(--pf-v6-c-log-viewer--Height);
   max-height: var(--pf-v6-c-log-viewer--MaxHeight);
 }
-.pf-v6-c-log-viewer.pf-v6-theme-dark {
+.pf-v6-c-log-viewer.pf-m-dark {
   --pf-v6-c-log-viewer__main--BorderWidth: var(--pf-v6-c-log-viewer--m-dark__main--BorderWidth);
 }
-.pf-v6-c-log-viewer.pf-v6-theme-dark .pf-v6-c-log-viewer__main {
-  --pf-v6-c-log-viewer__main--BackgroundColor: var(--pf-t--global--background--color--primary--default);
+html:not(.pf-v6-theme-dark) .pf-v6-c-log-viewer.pf-m-dark .pf-v6-c-log-viewer__main {
+  --pf-v6-c-log-viewer__main--BackgroundColor: var(--pf-t--global--background--color--inverse--default);
   --pf-v6-c-log-viewer__main--BorderColor: var(--pf-t--global--border--color--default);
-  --pf-v6-c-log-viewer__text--Color: var(--pf-t--global--text--color--regular);
-  --pf-v6-c-log-viewer__index--Color: var(--pf-t--global--text--color--subtle);
+  --pf-v6-c-log-viewer__text--Color: var(--pf-t--global--text--color--inverse);
+  --pf-v6-c-log-viewer__index--Color: var(--pf-t--global--text--color--inverse);
   --pf-v6-c-log-viewer--m-line-numbers__list--before--BackgroundColor: var(--pf-t--global--border--color--default);
 }
 .pf-v6-c-log-viewer.pf-m-wrap-text {

--- a/packages/module/src/LogViewer/css/log-viewer.css
+++ b/packages/module/src/LogViewer/css/log-viewer.css
@@ -54,16 +54,13 @@
   max-height: var(--pf-v6-c-log-viewer--MaxHeight);
 }
 
-.pf-v6-c-log-viewer.pf-m-dark {
+html:not(.pf-v6-theme-dark) .pf-v6-c-log-viewer.pf-m-dark { 
   --pf-v6-c-log-viewer__main--BorderWidth: var(--pf-v6-c-log-viewer--m-dark__main--BorderWidth);
+  --pf-v6-c-log-viewer__main--BackgroundColor: var(--pf-v6-c-log-viewer--m-dark__main--BackgroundColor); 
+  --pf-v6-c-log-viewer__text--Color: var(--pf-v6-c-log-viewer--m-dark__text--Color); 
+  --pf-v6-c-log-viewer__index--Color: var( --pf-v6-c-log-viewer--m-dark__index--Color); 
 }
-html:not(.pf-v6-theme-dark) .pf-v6-c-log-viewer.pf-m-dark .pf-v6-c-log-viewer__main {
-  --pf-v6-c-log-viewer__main--BackgroundColor: var(--pf-v6-c-log-viewer--m-dark__main--BackgroundColor);
-  --pf-v6-c-log-viewer__main--BorderColor: var(--pf-t--global--border--color--default);
-  --pf-v6-c-log-viewer__text--Color: var(--pf-v6-c-log-viewer--m-dark__text--Color);
-  --pf-v6-c-log-viewer__index--Color: var( --pf-v6-c-log-viewer--m-dark__index--Color);
-  --pf-v6-c-log-viewer--m-line-numbers__list--before--BackgroundColor: var(--pf-t--global--border--color--default);
-}
+
 .pf-v6-c-log-viewer.pf-m-wrap-text {
   word-break: break-all;
 }

--- a/packages/module/src/LogViewer/css/log-viewer.css
+++ b/packages/module/src/LogViewer/css/log-viewer.css
@@ -45,19 +45,23 @@
   --pf-v6-c-log-viewer--c-toolbar__group--m-toggle-group--spacer: 0;
   --pf-v6-c-log-viewer--c-toolbar__group--m-toggle-group--m-show--spacer: var(--pf-t--global--spacer--sm);
   --pf-v6-c-log-viewer--m-dark__main--BorderWidth: 0;
+  --pf-v6-c-log-viewer--m-dark__main--BackgroundColor: var(--pf-t--global--background--color--inverse--default);
+  --pf-v6-c-log-viewer--m-dark__text--Color: var(--pf-t--global--text--color--inverse);
+  --pf-v6-c-log-viewer--m-dark__index--Color: var(--pf-t--global--text--color--inverse);
   display: flex;
   flex-direction: column;
   height: var(--pf-v6-c-log-viewer--Height);
   max-height: var(--pf-v6-c-log-viewer--MaxHeight);
 }
+
 .pf-v6-c-log-viewer.pf-m-dark {
   --pf-v6-c-log-viewer__main--BorderWidth: var(--pf-v6-c-log-viewer--m-dark__main--BorderWidth);
 }
 html:not(.pf-v6-theme-dark) .pf-v6-c-log-viewer.pf-m-dark .pf-v6-c-log-viewer__main {
-  --pf-v6-c-log-viewer__main--BackgroundColor: var(--pf-t--global--background--color--inverse--default);
+  --pf-v6-c-log-viewer__main--BackgroundColor: var(--pf-v6-c-log-viewer--m-dark__main--BackgroundColor);
   --pf-v6-c-log-viewer__main--BorderColor: var(--pf-t--global--border--color--default);
-  --pf-v6-c-log-viewer__text--Color: var(--pf-t--global--text--color--inverse);
-  --pf-v6-c-log-viewer__index--Color: var(--pf-t--global--text--color--inverse);
+  --pf-v6-c-log-viewer__text--Color: var(--pf-v6-c-log-viewer--m-dark__text--Color);
+  --pf-v6-c-log-viewer__index--Color: var( --pf-v6-c-log-viewer--m-dark__index--Color);
   --pf-v6-c-log-viewer--m-line-numbers__list--before--BackgroundColor: var(--pf-t--global--border--color--default);
 }
 .pf-v6-c-log-viewer.pf-m-wrap-text {

--- a/packages/module/src/LogViewer/css/log-viewer.ts
+++ b/packages/module/src/LogViewer/css/log-viewer.ts
@@ -11,6 +11,7 @@ export default {
   "logViewerText": "pf-v6-c-log-viewer__text",
   "logViewerTimestamp": "pf-v6-c-log-viewer__timestamp",
   "modifiers": {
+    "dark": "pf-m-dark",
     "wrapText": "pf-m-wrap-text",
     "nowrap": "pf-m-nowrap",
     "lineNumbers": "pf-m-line-numbers",


### PR DESCRIPTION
Updated code to add the ability to always apply a dark theme to the log viewer.


https://issue82-logviewer.surge.sh